### PR TITLE
2 Bugfixes : missing namespace for the GuzzleHTTP client and fix attribute name

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -206,7 +206,7 @@ class Message
      */
     public function setIsMarketing($isMarketing)
     {
-        $this->marketing = $isMarketing;
+        $this->isMarketing = $isMarketing;
     }
 
     /**

--- a/src/SmsApi.php
+++ b/src/SmsApi.php
@@ -31,6 +31,7 @@
 namespace Ovh\Sms;
 
 use Ovh\Api;
+use GuzzleHttp\Client;
 
 /**
  * Wrapper to manage login and exchanges with Ovh API


### PR DESCRIPTION
Bonjour,

je fais cette PR car vous avez oublié l'appel du namespace de GuzzleHttp dans la classe `SmsApi`. 
Donc quand l'on faisait ceci :

``` php
$client = new \GuzzleHttp\Client;
$sms = new SmsApi($this->app_key, $this->app_secret, 'ovh-eu', $this->consumer_key, $client);
```

Cela sortait une erreur, car la classe `Ovh\Sms\Client` n'existe pas.

Enjoy.
