### PR TITLE
Use user context for message deletion if provided

### DIFF
--- a/src/Sms.php
+++ b/src/Sms.php
@@ -168,12 +168,12 @@ class Sms
     /**
      * Delete the SMS
      *
-     * @return void
+     * @return array
      * @throws \GuzzleHttp\Exception\ClientException if http request returns an error
      */
     public function delete()
     {
-        return $this->Sms->getConnection()->delete('/sms/'.$this->Sms->getAccount().'/'.$this->type.'/'.$this->id);
+        return $this->Sms->getConnection()->delete($this->Sms->getUri().$this->type.'/'.$this->id);
     }
 
 


### PR DESCRIPTION
To allow a better usage of api user accounts with only user contextual rights, we use the contextual route if the user is defined

Without user :
/sms/_my-account_/_type_/_id_

With user :
/sms/_my-account_/users/_my-user_/_type_/_id_