### PR TITLE
Mise à jour de l'URL d'accès à l'API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Send SMS directly from your code using OVH SMS offer.
 ```php
 <?php
 /**
- * # Instantiate. Visit https://api.ovh.com/createToken/index.cgi?GET=/sms&GET=/sms/*&PUT=/sms/*&DELETE=/sms/*&POST=/sms/*
+ * # Instantiate. Visit https://api.ovh.com/createToken/index.cgi?GET=/sms/*&PUT=/sms/*&DELETE=/sms/*&POST=/sms/*
  * to get your credentials
  */
 require __DIR__ . '/vendor/autoload.php';
@@ -55,7 +55,7 @@ Even better, the credentials can be configured to only allow access on some spec
 features. In this case, we only want the script to access the SMS features.
 
 To generate credentials to access all the SMS features, you can simply visit
-https://api.ovh.com/createToken/index.cgi?GET=/sms&GET=/sms/*&PUT=/sms/*&DELETE=/sms/*&POST=/sms/*
+https://api.ovh.com/createToken/index.cgi?GET=/sms/*&PUT=/sms/*&DELETE=/sms/*&POST=/sms/*
 
 And then use the generated credentials in you application.
 


### PR DESCRIPTION
à la première utilisation de l'url j'ai eu certains problèmes au niveau des droits d'accès et c'était du au fait que l'url avait en paramètre deux fois le GET : une qui autorise juste l'url /sms/ et l'autre qui autorise à la fois l'accès à l'url /sms/ et aussi tout ses urls enfants. 