### PR TITLE
Fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Even better, the credentials can be configured to only allow access on some spec
 features. In this case, we only want the script to access the SMS features.
 
 To generate credentials to access all the SMS features, you can simply visit
-https://api.ovh.com/createToken/index.cgi?GET=/sms&GET=/sms/*&PUT=/sms/*&DELETE=/sms/*&POST=/sms/*
+[https://api.ovh.com/createToken/index.cgi?GET=/sms&GET=/sms/\*&PUT=/sms/\*&DELETE=/sms/\*&POST=/sms/\*](https://api.ovh.com/createToken/index.cgi?GET=/sms&GET=/sms/*&PUT=/sms/*&DELETE=/sms/*&POST=/sms/*)
 
 And then use the generated credentials in you application.
 


### PR DESCRIPTION
Format API credentials creation link so the last \* is included in URL. I used the link as is without noticing and had to debug why my post was being refused.